### PR TITLE
Escape * and _ characters.

### DIFF
--- a/src/utils/converters.js
+++ b/src/utils/converters.js
@@ -87,6 +87,9 @@ function getText(element, {isHeader = false} = {}) {
     bold,
     italic,
   } = element.textRun.textStyle
+  
+  text = text.replace(/\*/g, '\\*')
+  text = text.replace(/_/g, '\\_')
 
   if (underline) {
     // Underline isn't supported in markdown so we'll use emphasis


### PR DESCRIPTION
Or else they are treated as emphasis delimiters.