### PR TITLE
Documentation: Fix syntax for query variables

### DIFF
--- a/docs/pages.md
+++ b/docs/pages.md
@@ -15,14 +15,16 @@ export default ({data: {post}}) => (
     </>
 )
 
-export const pageQuery = graphql`
-    post: googleDocs(document: {path: {eq: $path}}) {
-        document {
-            name
-            createdTime
-        }
-        childMarkdownRemark {
-            html
+export const query = graphql`
+    query($path: String) {
+        post: googleDocs(document: {path: {eq: $path}}) {
+            document {
+                name
+                createdTime
+            }
+            childMarkdownRemark {
+                html
+            }
         }
     }
 `


### PR DESCRIPTION
The syntax from the doc is breaking for me. Not sure if this is something that changed recently, but the official Gatsby docs recommend [this way](https://www.gatsbyjs.org/docs/page-query/#how-to-add-query-variables-to-a-page-query) to query vars.
