### PR TITLE
Add handling of Footnotes from Google Docs

### DIFF
--- a/src/utils/converters.js
+++ b/src/utils/converters.js
@@ -254,7 +254,7 @@ function convertGoogleDocumentToJson(document) {
 
   // Footnotes
   let formatedFootnotes = []
-  Object.entries(footnotes).forEach(({value}) => {
+  Object.entries(footnotes).forEach(([, value]) => {
     // Concatenate all content
     const text_items = value.content[0].paragraph.elements.map(element =>
       getText(element)
@@ -280,7 +280,7 @@ function convertGoogleDocumentToJson(document) {
 }
 
 // Extra converter for footnotes
-json2md.converters.footnote = function({footnote}) {
+json2md.converters.footnote = function(footnote) {
   return `[^${footnote.number}]: ${footnote.text}`
 }
 

--- a/src/utils/converters.js
+++ b/src/utils/converters.js
@@ -213,7 +213,7 @@ function convertGoogleDocumentToJson(document) {
               })
             }
           }
-          
+
           // Headings, Texts
           else if (el.textRun && el.textRun.content !== "\n") {
             tagContent.push({

--- a/src/utils/converters.js
+++ b/src/utils/converters.js
@@ -162,6 +162,7 @@ function convertGoogleDocumentToJson(document) {
     // Paragraphs
     if (paragraph) {
       const tag = getParagraphTag(paragraph)
+      
       // Lists
       if (paragraph.bullet) {
         const listId = paragraph.bullet.listId
@@ -220,6 +221,7 @@ function convertGoogleDocumentToJson(document) {
               }),
             })
           }
+          
           // Footnotes
           else if (el.footnoteReference) {
             tagContent.push({

--- a/src/utils/converters.js
+++ b/src/utils/converters.js
@@ -162,7 +162,7 @@ function convertGoogleDocumentToJson(document) {
     // Paragraphs
     if (paragraph) {
       const tag = getParagraphTag(paragraph)
-      
+
       // Lists
       if (paragraph.bullet) {
         const listId = paragraph.bullet.listId

--- a/src/utils/converters.js
+++ b/src/utils/converters.js
@@ -213,6 +213,7 @@ function convertGoogleDocumentToJson(document) {
               })
             }
           }
+          
           // Headings, Texts
           else if (el.textRun && el.textRun.content !== "\n") {
             tagContent.push({

--- a/src/utils/google-auth.js
+++ b/src/utils/google-auth.js
@@ -1,5 +1,9 @@
 // const fs = require("fs")
 // const path = require("path")
+require("dotenv").config({
+  path: `.env`,
+})
+
 const {google} = require("googleapis")
 
 // const googledocsPath = path.join(process.cwd(), ".google")

--- a/src/utils/google-auth.js
+++ b/src/utils/google-auth.js
@@ -1,9 +1,5 @@
 // const fs = require("fs")
 // const path = require("path")
-require("dotenv").config({
-  path: `.env`,
-})
-
 const {google} = require("googleapis")
 
 // const googledocsPath = path.join(process.cwd(), ".google")


### PR DESCRIPTION
This PR adds handling of Footnotes: https://github.com/cedricdelpoux/gatsby-source-google-docs/issues/65

I'm a JS/Gatsby novice, so apologies if this isn't up to standard.

I found that the Husky precommit hook applied a bunch of formatting changes which confused the PR rather - I've tried to revert these but might be worth bearing in mind for the future (removal of blank lines, changing line length etc.)

Working example, with [Littlefoot](https://github.com/goblindegook/littlefoot): https://xenodochial-allen-667626.netlify.app/using-subjective-well-being-to-estimate-the-moral-weights-of-averting-deaths-and-reducing-poverty