### PR TITLE
fix: cross-documents links behavior

### DIFF
--- a/__tests__/__snapshots__/converter-markdown.js.snap
+++ b/__tests__/__snapshots__/converter-markdown.js.snap
@@ -82,6 +82,24 @@ cover: null
 "
 `;
 
+exports[`Document "Links" to Markdown 1`] = `
+"---
+cover: null
+---
+
+[to self](https://docs.google.com/document/d/1UuBxtIEEVh98wyBR9fMmLqzJEkmNlAMMoC4SEhprHfQ)
+
+
+[to self with user id](https://docs.google.com/document/u/1/d/1UuBxtIEEVh98wyBR9fMmLqzJEkmNlAMMoC4SEhprHfQ)
+
+
+[to self with edit](https://docs.google.com/document/d/1UuBxtIEEVh98wyBR9fMmLqzJEkmNlAMMoC4SEhprHfQ/edit)
+
+
+[to self with preview](https://docs.google.com/document/d/1UuBxtIEEVh98wyBR9fMmLqzJEkmNlAMMoC4SEhprHfQ/preview)
+"
+`;
+
 exports[`Document "Lists" to Markdown 1`] = `
 "---
 cover: null

--- a/__tests__/__snapshots__/converter-object.js.snap
+++ b/__tests__/__snapshots__/converter-object.js.snap
@@ -281,3 +281,76 @@ Object {
   "metadata": Object {},
 }
 `;
+
+exports[`Document "Texts" to Object with links  1`] = `
+Object {
+  "cover": null,
+  "elements": Array [
+    Object {
+      "type": "h1",
+      "value": "Title level 1",
+    },
+    Object {
+      "type": "h2",
+      "value": "Title level 2",
+    },
+    Object {
+      "type": "h3",
+      "value": "Title level 3",
+    },
+    Object {
+      "type": "h4",
+      "value": "Title level 4",
+    },
+    Object {
+      "type": "h5",
+      "value": "Title level 5",
+    },
+    Object {
+      "type": "h6",
+      "value": "Title level 6",
+    },
+    Object {
+      "type": "p",
+      "value": "**bold**",
+    },
+    Object {
+      "type": "p",
+      "value": "_italic_",
+    },
+    Object {
+      "type": "p",
+      "value": "<ins>underline</ins>",
+    },
+    Object {
+      "type": "p",
+      "value": "~~strikethrough~~ ",
+    },
+    Object {
+      "type": "p",
+      "value": "<sup>superscript</sup>",
+    },
+    Object {
+      "type": "p",
+      "value": "<sub>subscript</sub>",
+    },
+    Object {
+      "type": "p",
+      "value": "**_boldItalic_**",
+    },
+    Object {
+      "type": "p",
+      "value": "text with **space bold after** and _space italic before_.",
+    },
+    Object {
+      "type": "p",
+      "value": "		indented text",
+    },
+    Object {
+      "type": "p",
+      "value": "[Link to itself](/itself)",
+    },
+  ],
+  "metadata": Object {},
+}
+`;

--- a/__tests__/__snapshots__/converter-object.js.snap
+++ b/__tests__/__snapshots__/converter-object.js.snap
@@ -123,6 +123,56 @@ Object {
 }
 `;
 
+exports[`Document "Links" to Object 1`] = `
+Object {
+  "cover": null,
+  "elements": Array [
+    Object {
+      "type": "p",
+      "value": "[to self](https://docs.google.com/document/d/1UuBxtIEEVh98wyBR9fMmLqzJEkmNlAMMoC4SEhprHfQ)",
+    },
+    Object {
+      "type": "p",
+      "value": "[to self with user id](https://docs.google.com/document/u/1/d/1UuBxtIEEVh98wyBR9fMmLqzJEkmNlAMMoC4SEhprHfQ)",
+    },
+    Object {
+      "type": "p",
+      "value": "[to self with edit](https://docs.google.com/document/d/1UuBxtIEEVh98wyBR9fMmLqzJEkmNlAMMoC4SEhprHfQ/edit)",
+    },
+    Object {
+      "type": "p",
+      "value": "[to self with preview](https://docs.google.com/document/d/1UuBxtIEEVh98wyBR9fMmLqzJEkmNlAMMoC4SEhprHfQ/preview)",
+    },
+  ],
+  "metadata": Object {},
+}
+`;
+
+exports[`Document "Links" to Object with links  1`] = `
+Object {
+  "cover": null,
+  "elements": Array [
+    Object {
+      "type": "p",
+      "value": "[to self](/itself)",
+    },
+    Object {
+      "type": "p",
+      "value": "[to self with user id](/itself)",
+    },
+    Object {
+      "type": "p",
+      "value": "[to self with edit](/itself)",
+    },
+    Object {
+      "type": "p",
+      "value": "[to self with preview](/itself)",
+    },
+  ],
+  "metadata": Object {},
+}
+`;
+
 exports[`Document "Lists" to Object 1`] = `
 Object {
   "cover": null,

--- a/__tests__/converter-object.js
+++ b/__tests__/converter-object.js
@@ -17,7 +17,7 @@ filenames.forEach(function (filename) {
     expect(documentObject).toMatchSnapshot()
   })
 
-  if (filename === "texts.json") {
+  if (filename === "texts.json" || filename === "links.json") {
     const options = {
       crosslinksPaths: {[sourceDoc.documentId]: "/itself"},
     }

--- a/__tests__/converter-object.js
+++ b/__tests__/converter-object.js
@@ -9,10 +9,22 @@ const filenames = fs.readdirSync(documentsPath)
 filenames.forEach(function (filename) {
   const filepath = path.join(documentsPath, filename)
   const file = fs.readFileSync(filepath, "utf8")
-  const googleDocument = new GoogleDocument(JSON.parse(file))
+  const sourceDoc = JSON.parse(file)
+  const googleDocument = new GoogleDocument(sourceDoc)
 
   test(`Document "${googleDocument.document.title}" to Object`, () => {
     const documentObject = googleDocument.toObject()
     expect(documentObject).toMatchSnapshot()
   })
+
+  if (filename === "texts.json") {
+    const options = {
+      crosslinksPaths: {[sourceDoc.documentId]: "/itself"},
+    }
+    const doc = new GoogleDocument(JSON.parse(file), {}, options)
+    test(`Document "${googleDocument.document.title}" to Object with links `, () => {
+      const documentObject = doc.toObject()
+      expect(documentObject).toMatchSnapshot()
+    })
+  }
 })

--- a/__tests__/documents/links.json
+++ b/__tests__/documents/links.json
@@ -1,0 +1,606 @@
+{
+  "title": "Links",
+  "body": {
+    "content": [
+      {
+        "endIndex": 1,
+        "sectionBreak": {
+          "sectionStyle": {
+            "columnSeparatorStyle": "NONE",
+            "contentDirection": "LEFT_TO_RIGHT",
+            "sectionType": "CONTINUOUS"
+          }
+        }
+      },
+      {
+        "startIndex": 1,
+        "endIndex": 9,
+        "paragraph": {
+          "elements": [
+            {
+              "startIndex": 1,
+              "endIndex": 8,
+              "textRun": {
+                "content": "to self",
+                "textStyle": {
+                  "underline": true,
+                  "foregroundColor": {
+                    "color": {
+                      "rgbColor": {
+                        "red": 0.06666667,
+                        "green": 0.33333334,
+                        "blue": 0.8
+                      }
+                    }
+                  },
+                  "link": {
+                    "url": "https://docs.google.com/document/d/1UuBxtIEEVh98wyBR9fMmLqzJEkmNlAMMoC4SEhprHfQ"
+                  }
+                }
+              }
+            },
+            {
+              "startIndex": 8,
+              "endIndex": 9,
+              "textRun": {
+                "content": "\n",
+                "textStyle": {}
+              }
+            }
+          ],
+          "paragraphStyle": {
+            "namedStyleType": "NORMAL_TEXT",
+            "direction": "LEFT_TO_RIGHT"
+          }
+        }
+      },
+      {
+        "startIndex": 9,
+        "endIndex": 10,
+        "paragraph": {
+          "elements": [
+            {
+              "startIndex": 9,
+              "endIndex": 10,
+              "textRun": {
+                "content": "\n",
+                "textStyle": {}
+              }
+            }
+          ],
+          "paragraphStyle": {
+            "namedStyleType": "NORMAL_TEXT",
+            "direction": "LEFT_TO_RIGHT"
+          }
+        }
+      },
+      {
+        "startIndex": 10,
+        "endIndex": 31,
+        "paragraph": {
+          "elements": [
+            {
+              "startIndex": 10,
+              "endIndex": 30,
+              "textRun": {
+                "content": "to self with user id",
+                "textStyle": {
+                  "underline": true,
+                  "foregroundColor": {
+                    "color": {
+                      "rgbColor": {
+                        "red": 0.06666667,
+                        "green": 0.33333334,
+                        "blue": 0.8
+                      }
+                    }
+                  },
+                  "link": {
+                    "url": "https://docs.google.com/document/u/1/d/1UuBxtIEEVh98wyBR9fMmLqzJEkmNlAMMoC4SEhprHfQ"
+                  }
+                }
+              }
+            },
+            {
+              "startIndex": 30,
+              "endIndex": 31,
+              "textRun": {
+                "content": "\n",
+                "textStyle": {}
+              }
+            }
+          ],
+          "paragraphStyle": {
+            "namedStyleType": "NORMAL_TEXT",
+            "direction": "LEFT_TO_RIGHT"
+          }
+        }
+      },
+      {
+        "startIndex": 31,
+        "endIndex": 32,
+        "paragraph": {
+          "elements": [
+            {
+              "startIndex": 31,
+              "endIndex": 32,
+              "textRun": {
+                "content": "\n",
+                "textStyle": {}
+              }
+            }
+          ],
+          "paragraphStyle": {
+            "namedStyleType": "NORMAL_TEXT",
+            "direction": "LEFT_TO_RIGHT"
+          }
+        }
+      },
+      {
+        "startIndex": 32,
+        "endIndex": 50,
+        "paragraph": {
+          "elements": [
+            {
+              "startIndex": 32,
+              "endIndex": 49,
+              "textRun": {
+                "content": "to self with edit",
+                "textStyle": {
+                  "underline": true,
+                  "foregroundColor": {
+                    "color": {
+                      "rgbColor": {
+                        "red": 0.06666667,
+                        "green": 0.33333334,
+                        "blue": 0.8
+                      }
+                    }
+                  },
+                  "link": {
+                    "url": "https://docs.google.com/document/d/1UuBxtIEEVh98wyBR9fMmLqzJEkmNlAMMoC4SEhprHfQ/edit"
+                  }
+                }
+              }
+            },
+            {
+              "startIndex": 49,
+              "endIndex": 50,
+              "textRun": {
+                "content": "\n",
+                "textStyle": {}
+              }
+            }
+          ],
+          "paragraphStyle": {
+            "namedStyleType": "NORMAL_TEXT",
+            "direction": "LEFT_TO_RIGHT"
+          }
+        }
+      },
+      {
+        "startIndex": 50,
+        "endIndex": 51,
+        "paragraph": {
+          "elements": [
+            {
+              "startIndex": 50,
+              "endIndex": 51,
+              "textRun": {
+                "content": "\n",
+                "textStyle": {}
+              }
+            }
+          ],
+          "paragraphStyle": {
+            "namedStyleType": "NORMAL_TEXT",
+            "direction": "LEFT_TO_RIGHT"
+          }
+        }
+      },
+      {
+        "startIndex": 51,
+        "endIndex": 72,
+        "paragraph": {
+          "elements": [
+            {
+              "startIndex": 51,
+              "endIndex": 71,
+              "textRun": {
+                "content": "to self with preview",
+                "textStyle": {
+                  "underline": true,
+                  "foregroundColor": {
+                    "color": {
+                      "rgbColor": {
+                        "red": 0.06666667,
+                        "green": 0.33333334,
+                        "blue": 0.8
+                      }
+                    }
+                  },
+                  "link": {
+                    "url": "https://docs.google.com/document/d/1UuBxtIEEVh98wyBR9fMmLqzJEkmNlAMMoC4SEhprHfQ/preview"
+                  }
+                }
+              }
+            },
+            {
+              "startIndex": 71,
+              "endIndex": 72,
+              "textRun": {
+                "content": "\n",
+                "textStyle": {}
+              }
+            }
+          ],
+          "paragraphStyle": {
+            "namedStyleType": "NORMAL_TEXT",
+            "direction": "LEFT_TO_RIGHT"
+          }
+        }
+      }
+    ]
+  },
+  "documentStyle": {
+    "background": {
+      "color": {}
+    },
+    "pageNumberStart": 1,
+    "marginTop": {
+      "magnitude": 72,
+      "unit": "PT"
+    },
+    "marginBottom": {
+      "magnitude": 72,
+      "unit": "PT"
+    },
+    "marginRight": {
+      "magnitude": 72,
+      "unit": "PT"
+    },
+    "marginLeft": {
+      "magnitude": 72,
+      "unit": "PT"
+    },
+    "pageSize": {
+      "height": {
+        "magnitude": 792,
+        "unit": "PT"
+      },
+      "width": {
+        "magnitude": 612,
+        "unit": "PT"
+      }
+    },
+    "marginHeader": {
+      "magnitude": 36,
+      "unit": "PT"
+    },
+    "marginFooter": {
+      "magnitude": 36,
+      "unit": "PT"
+    },
+    "useCustomHeaderFooterMargins": true
+  },
+  "namedStyles": {
+    "styles": [
+      {
+        "namedStyleType": "NORMAL_TEXT",
+        "textStyle": {
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "smallCaps": false,
+          "backgroundColor": {},
+          "foregroundColor": {
+            "color": {
+              "rgbColor": {}
+            }
+          },
+          "fontSize": {
+            "magnitude": 11,
+            "unit": "PT"
+          },
+          "weightedFontFamily": {
+            "fontFamily": "Arial",
+            "weight": 400
+          },
+          "baselineOffset": "NONE"
+        },
+        "paragraphStyle": {
+          "namedStyleType": "NORMAL_TEXT",
+          "alignment": "START",
+          "lineSpacing": 115,
+          "direction": "LEFT_TO_RIGHT",
+          "spacingMode": "COLLAPSE_LISTS",
+          "spaceAbove": {
+            "unit": "PT"
+          },
+          "spaceBelow": {
+            "unit": "PT"
+          },
+          "borderBetween": {
+            "color": {},
+            "width": {
+              "unit": "PT"
+            },
+            "padding": {
+              "unit": "PT"
+            },
+            "dashStyle": "SOLID"
+          },
+          "borderTop": {
+            "color": {},
+            "width": {
+              "unit": "PT"
+            },
+            "padding": {
+              "unit": "PT"
+            },
+            "dashStyle": "SOLID"
+          },
+          "borderBottom": {
+            "color": {},
+            "width": {
+              "unit": "PT"
+            },
+            "padding": {
+              "unit": "PT"
+            },
+            "dashStyle": "SOLID"
+          },
+          "borderLeft": {
+            "color": {},
+            "width": {
+              "unit": "PT"
+            },
+            "padding": {
+              "unit": "PT"
+            },
+            "dashStyle": "SOLID"
+          },
+          "borderRight": {
+            "color": {},
+            "width": {
+              "unit": "PT"
+            },
+            "padding": {
+              "unit": "PT"
+            },
+            "dashStyle": "SOLID"
+          },
+          "indentFirstLine": {
+            "unit": "PT"
+          },
+          "indentStart": {
+            "unit": "PT"
+          },
+          "indentEnd": {
+            "unit": "PT"
+          },
+          "keepLinesTogether": false,
+          "keepWithNext": false,
+          "avoidWidowAndOrphan": true,
+          "shading": {
+            "backgroundColor": {}
+          }
+        }
+      },
+      {
+        "namedStyleType": "HEADING_1",
+        "textStyle": {
+          "fontSize": {
+            "magnitude": 20,
+            "unit": "PT"
+          }
+        },
+        "paragraphStyle": {
+          "namedStyleType": "NORMAL_TEXT",
+          "direction": "LEFT_TO_RIGHT",
+          "spaceAbove": {
+            "magnitude": 20,
+            "unit": "PT"
+          },
+          "spaceBelow": {
+            "magnitude": 6,
+            "unit": "PT"
+          },
+          "keepLinesTogether": true,
+          "keepWithNext": true
+        }
+      },
+      {
+        "namedStyleType": "HEADING_2",
+        "textStyle": {
+          "bold": true,
+          "underline": true
+        },
+        "paragraphStyle": {
+          "headingId": "h.crrpgju8ws84",
+          "namedStyleType": "HEADING_2",
+          "direction": "LEFT_TO_RIGHT",
+          "spaceAbove": {
+            "magnitude": 18,
+            "unit": "PT"
+          },
+          "spaceBelow": {
+            "magnitude": 6,
+            "unit": "PT"
+          },
+          "keepLinesTogether": true,
+          "keepWithNext": true
+        }
+      },
+      {
+        "namedStyleType": "HEADING_3",
+        "textStyle": {
+          "bold": true
+        },
+        "paragraphStyle": {
+          "headingId": "h.yrkcs963nbig",
+          "namedStyleType": "HEADING_3",
+          "direction": "LEFT_TO_RIGHT",
+          "spaceAbove": {
+            "magnitude": 16,
+            "unit": "PT"
+          },
+          "spaceBelow": {
+            "magnitude": 4,
+            "unit": "PT"
+          },
+          "keepLinesTogether": true,
+          "keepWithNext": true
+        }
+      },
+      {
+        "namedStyleType": "HEADING_4",
+        "textStyle": {
+          "underline": true
+        },
+        "paragraphStyle": {
+          "headingId": "h.2pgom3u1ze8f",
+          "namedStyleType": "HEADING_4",
+          "direction": "LEFT_TO_RIGHT",
+          "spaceAbove": {
+            "magnitude": 14,
+            "unit": "PT"
+          },
+          "spaceBelow": {
+            "magnitude": 4,
+            "unit": "PT"
+          },
+          "keepLinesTogether": true,
+          "keepWithNext": true
+        }
+      },
+      {
+        "namedStyleType": "HEADING_5",
+        "textStyle": {
+          "foregroundColor": {
+            "color": {
+              "rgbColor": {
+                "red": 0.4,
+                "green": 0.4,
+                "blue": 0.4
+              }
+            }
+          },
+          "fontSize": {
+            "magnitude": 11,
+            "unit": "PT"
+          }
+        },
+        "paragraphStyle": {
+          "namedStyleType": "NORMAL_TEXT",
+          "direction": "LEFT_TO_RIGHT",
+          "spaceAbove": {
+            "magnitude": 12,
+            "unit": "PT"
+          },
+          "spaceBelow": {
+            "magnitude": 4,
+            "unit": "PT"
+          },
+          "keepLinesTogether": true,
+          "keepWithNext": true
+        }
+      },
+      {
+        "namedStyleType": "HEADING_6",
+        "textStyle": {
+          "italic": true,
+          "foregroundColor": {
+            "color": {
+              "rgbColor": {
+                "red": 0.4,
+                "green": 0.4,
+                "blue": 0.4
+              }
+            }
+          },
+          "fontSize": {
+            "magnitude": 11,
+            "unit": "PT"
+          }
+        },
+        "paragraphStyle": {
+          "namedStyleType": "NORMAL_TEXT",
+          "direction": "LEFT_TO_RIGHT",
+          "spaceAbove": {
+            "magnitude": 12,
+            "unit": "PT"
+          },
+          "spaceBelow": {
+            "magnitude": 4,
+            "unit": "PT"
+          },
+          "keepLinesTogether": true,
+          "keepWithNext": true
+        }
+      },
+      {
+        "namedStyleType": "TITLE",
+        "textStyle": {
+          "bold": true,
+          "fontSize": {
+            "magnitude": 18,
+            "unit": "PT"
+          }
+        },
+        "paragraphStyle": {
+          "headingId": "h.v0sy8ume7683",
+          "namedStyleType": "TITLE",
+          "alignment": "CENTER",
+          "direction": "LEFT_TO_RIGHT",
+          "spaceBelow": {
+            "magnitude": 3,
+            "unit": "PT"
+          },
+          "keepLinesTogether": true,
+          "keepWithNext": true
+        }
+      },
+      {
+        "namedStyleType": "SUBTITLE",
+        "textStyle": {
+          "italic": false,
+          "foregroundColor": {
+            "color": {
+              "rgbColor": {
+                "red": 0.4,
+                "green": 0.4,
+                "blue": 0.4
+              }
+            }
+          },
+          "fontSize": {
+            "magnitude": 15,
+            "unit": "PT"
+          },
+          "weightedFontFamily": {
+            "fontFamily": "Arial",
+            "weight": 400
+          }
+        },
+        "paragraphStyle": {
+          "namedStyleType": "NORMAL_TEXT",
+          "direction": "LEFT_TO_RIGHT",
+          "spaceAbove": {
+            "unit": "PT"
+          },
+          "spaceBelow": {
+            "magnitude": 16,
+            "unit": "PT"
+          },
+          "keepLinesTogether": true,
+          "keepWithNext": true
+        }
+      }
+    ]
+  },
+  "revisionId": "ALm37BX_6dRY7ymQxjaUV7wPyC3GsVLNFxPNp7tlKNo6tshN9jZCFXNFhN0kAnzlUJi8684QZ9uDa4I72wQq7w",
+  "suggestionsViewMode": "SUGGESTIONS_INLINE",
+  "documentId": "1UuBxtIEEVh98wyBR9fMmLqzJEkmNlAMMoC4SEhprHfQ"
+}

--- a/utils/google-document.js
+++ b/utils/google-document.js
@@ -460,12 +460,10 @@ class GoogleDocument {
     if (Object.keys(this.crosslinksPaths).length > 0) {
       let elementsStringify = JSON.stringify(elements)
 
-      Object.keys(this.crosslinksPaths).forEach((id) => {
-        elementsStringify = elementsStringify.replace(
-          `https://docs.google.com/document/d/${id}`,
-          this.crosslinksPaths[id]
-        )
-      })
+      elementsStringify = elementsStringify.replace(
+        /https:\/\/docs.google.com\/document\/(?:u\/\d+\/)?d\/([a-zA-Z0-9]+)(?:\/edit|\/preview)?/g,
+        (match, id) => this.crosslinksPaths[id] || match
+      )
 
       elements = JSON.parse(elementsStringify)
     }


### PR DESCRIPTION
Google docs links can contain `/u/1` and a trailing `/edit`, and that usually needs to be removed.