### PR TITLE
fix: dont spread a string

### DIFF
--- a/utils/google-drive.js
+++ b/utils/google-drive.js
@@ -49,7 +49,9 @@ const updateMetadata = ({metadata, fieldsDefault = {}, fieldsMapper = {}}) => {
     try {
       // Try to convert description from YAML
       const descriptionObject = yamljs.parse(metadata.description)
-      metadata = {...metadata, ...descriptionObject}
+      if (typeof descriptionObject !== "string") {
+        metadata = {...metadata, ...descriptionObject}
+      }
     } catch (e) {
       // Description field is not valid YAML
       // Do not throw an error


### PR DESCRIPTION
It leads to stuff like {0: 'D', 1: 'e', 2: 's', 3: 'c'} ...