### PR TITLE
fix: add - and _ to the google docs id regex

### DIFF
--- a/utils/google-document.js
+++ b/utils/google-document.js
@@ -468,7 +468,7 @@ class GoogleDocument {
       let elementsStringify = JSON.stringify(elements)
 
       elementsStringify = elementsStringify.replace(
-        /https:\/\/docs.google.com\/document\/(?:u\/\d+\/)?d\/([a-zA-Z0-9]+)(?:\/edit|\/preview)?/g,
+        /https:\/\/docs.google.com\/document\/(?:u\/\d+\/)?d\/([a-zA-Z0-9_-]+)(?:\/edit|\/preview)?/g,
         (match, id) => this.crosslinksPaths[id] || match
       )
 


### PR DESCRIPTION
*sigh* found a new issue with the regex, it needs `_` and `-`, as the Google IDs can have those 😝.