### PR TITLE
feat: Add template support for extensions other than .js

### DIFF
--- a/utils/create-pages.js
+++ b/utils/create-pages.js
@@ -3,7 +3,10 @@ const {resolve} = require("path")
 
 const {DEFAULT_TEMPLATE} = require("./constants.js")
 
-const getComponentPath = (template) => resolve(`src/templates/${template}.js`)
+const getComponentPath = (template) =>
+  template.includes(".")
+    ? resolve(`src/templates/${template}`)
+    : resolve(`src/templates/${template}.js`)
 
 exports.createPages = async (
   {graphql, actions: {createPage}, reporter},


### PR DESCRIPTION
When setting the YAML data this enables for support for things like:

`
template: post.tsx
`