### PR TITLE
Fixes broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Checkout the [example template](./example/src/templates/page.js) et adapt it to 
 
 <p><details><summary>How to create pages manualy?</summary>
 
-If you prefer to create pages manualy, checkout the [createPages API](./src/urils/create-pages.js) et adapt it to your needs.
+If you prefer to create pages manualy, checkout the [createPages API](./utils/create-pages.js) et adapt it to your needs.
 
 </details></p>
 


### PR DESCRIPTION
A link in the readme is broken under the "How to create pages manually?":
Currently, the link is https://github.com/cedricdelpoux/gatsby-source-google-docs/blob/master/src/urils/create-pages.js
and it should be https://github.com/cedricdelpoux/gatsby-source-google-docs/blob/master/example/src/templates/page.js.