### PR TITLE
feat: Support person tag and rich links

### DIFF
--- a/utils/google-document.js
+++ b/utils/google-document.js
@@ -44,6 +44,17 @@ class GoogleDocument {
       }
     }
 
+    // Person tag
+    if (el.person) {
+      return el.person.personProperties.name;
+    }
+
+    // Rich link
+    if (el.richLink) {
+      const props = el.richLink.richLinkProperties;
+      return `[${props.title}](${props.uri})`;
+    }
+
     if (!el.textRun || !el.textRun.content || !el.textRun.content.trim()) {
       return ""
     }


### PR DESCRIPTION
Adds support for the following:
- @<person>: Render's the name
- Rich Links e.g. Google Docs/Sheets/Slides chips: Renders as link with the title as text

Resolves #201.