### PR TITLE
fix: google docs changed the format of image url

### DIFF
--- a/utils/update-images.js
+++ b/utils/update-images.js
@@ -5,7 +5,7 @@ const {createRemoteFileNode} = require("gatsby-source-filesystem")
 const {getImageUrlParameters} = require("./get-image-url-parameters")
 
 const IMAGE_URL_REGEX =
-  /https:\/\/[a-z0-9]*.googleusercontent\.com\/docs\/[a-zA-Z0-9_=-]*/
+  /https:\/\/[a-z0-9]*.googleusercontent\.com\/(?:docs\/)?[a-zA-Z0-9_=-]*/
 const MD_URL_TITLE_REGEX = new RegExp(
   `(${IMAGE_URL_REGEX.source}) "([^)]*)"`,
   "g"


### PR DESCRIPTION
Simple fix for #222, #223 - not fully tested

Current format returned by Google in Markdown has this URL:

```https://lh6.googleusercontent.com/89p8N2d-jQXm28b73kaRPZjG8gCOzLqjT5l77tYcQMmfA6q9OClOdhx5OgsR_8d-QZdassadasdIHSuMbCyVJJYT_SKwS4tg1JaSQqTVvo1jwdCT9Oig00Evs9k0wg6lFHwq_Z8vWgcjivqLTK92HriucsQSZ```