### PR TITLE
Support image links with '-' in the domain name

### DIFF
--- a/utils/update-images.js
+++ b/utils/update-images.js
@@ -5,7 +5,7 @@ const {createRemoteFileNode} = require("gatsby-source-filesystem")
 const {getImageUrlParameters} = require("./get-image-url-parameters")
 
 const IMAGE_URL_REGEX =
-  /https:\/\/[a-z0-9]*.googleusercontent\.com\/(?:docs\/)?[a-zA-Z0-9_=-]*/
+  /https:\/\/[a-z0-9-]*.googleusercontent\.com\/(?:docs\/)?[a-zA-Z0-9_=-]*/
 const MD_URL_TITLE_REGEX = new RegExp(
   `(${IMAGE_URL_REGEX.source}) "([^)]*)"`,
   "g"


### PR DESCRIPTION
Images weren't being converted into static assets since the regex broke. I noticed the urls had `-` in the domain.

https://lh7-us.googleusercontent.com/...