### PR TITLE
Allow Google Doc comments to be pullable in GraphQL

### DIFF
--- a/utils/google-drive.js
+++ b/utils/google-drive.js
@@ -324,6 +324,15 @@ async function fetchFiles({folder, ...options}) {
     options,
   })
 
+    // Fetching comments for each file
+  for (let file of documentsFiles) {
+    const comments = await drive.comments.list({
+      fileId: file.id,
+      fields: 'comments'
+    });
+    file.comments = comments.data.comments;
+  }
+
   return documentsFiles
 }
 


### PR DESCRIPTION
Hey there, follow up from my previous comment [here](https://github.com/cedricdelpoux/gatsby-source-google-docs/pull/237#issuecomment-1979738652).

My main reason for needing to keep this forked as of now is to additionally pull in comments from my Google Docs files, as I use these comments for footnotes/margin notes. 

With the code provided, comments can be pulled in a GraphQL query like so:

```
page: googleDocs(slug: { eq: $path }) {
      comments {
          content
          }
      }
```

I understand this may not be desired behavior so feel free to not add it to the codebase. However, if you think it's a good idea, maybe this contribution could be helpful. Thanks!
